### PR TITLE
Viewable strings + allow_iframe_from correction

### DIFF
--- a/app/controllers/cms/pages_controller.rb
+++ b/app/controllers/cms/pages_controller.rb
@@ -1,6 +1,6 @@
 module CMS
   class PagesController < RailsAdminCMS::Config.parent_controller
-    after_action :allow_iframe, if: RailsAdminCMS::Config.allow_iframe_from
+    after_action :allow_iframe
 
     def show
       @cms_view = Viewable::Page.find(params[:id]) if params[:id].present?
@@ -15,7 +15,9 @@ module CMS
     private
 
     def allow_iframe
-      response.headers['X-FRAME-OPTIONS'] = RailsAdminCMS::Config.allow_iframe_from
+      if RailsAdminCMS::Config.allow_iframe_from.present?
+        response.headers['X-FRAME-OPTIONS'] = RailsAdminCMS::Config.allow_iframe_from
+      end
     end
   end
 end

--- a/app/models/admin/viewable/string.rb
+++ b/app/models/admin/viewable/string.rb
@@ -1,0 +1,15 @@
+module Admin
+  module Viewable
+    module String
+      extend ActiveSupport::Concern
+
+      included do
+        rails_admin do
+          visible false
+
+          field :title
+        end
+      end
+    end
+  end
+end

--- a/app/models/viewable/string.rb
+++ b/app/models/viewable/string.rb
@@ -1,0 +1,6 @@
+module Viewable
+  class String < ActiveRecord::Base
+    include Viewable
+    include Admin::Viewable::String
+  end
+end

--- a/app/presenters/viewable/string_presenter.rb
+++ b/app/presenters/viewable/string_presenter.rb
@@ -1,0 +1,7 @@
+module Viewable
+  class StringPresenter < ViewablePresenter
+    def text
+      h.strip_tags m.title
+    end
+  end
+end

--- a/db/migrate/20160201181310_create_viewable_string.rb
+++ b/db/migrate/20160201181310_create_viewable_string.rb
@@ -1,0 +1,9 @@
+class CreateViewableString < ActiveRecord::Migration
+  def change
+    create_table :viewable_strings do |t|
+        t.string     :title
+
+        t.timestamps null: false
+    end
+  end
+end


### PR DESCRIPTION
Viewable string feature was really missing in the CMS. Using text elements to display only a string was kind of an overkill and a lesser user experience.

Also, fixed a bug in allow_iframe_from modification.
